### PR TITLE
Readds the jet-pack to the engineering hardsuit.

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -118,6 +118,10 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
+	
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+	..()
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos


### PR DESCRIPTION
Readds the jetpack to the engi harsuit.
:cl:
tweak:The jet-pack was readded to the engineering hardsuit
/:cl:

The jet-pack was lost in the rebase. I see no reason for it to have been removed as it was quick useful for wiring solars and not getting lost in space.